### PR TITLE
ttrpc: support connection recovery with fdstore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,12 @@ nix = "0.23.0"
 log = "0.4"
 byteorder = "1.3.2"
 thiserror = "1.0"
+uuid = { version = "1.1.2", features = ["v4"] }
 
 async-trait = { version = "0.1.31", optional = true }
-tokio = { version = "1", features = ["rt", "sync", "io-util", "macros", "time"], optional = true }
+tokio = { version = "1", features = ["rt", "sync", "io-util", "macros", "time", "fs"], optional = true }
 futures = { version = "0.3", optional = true }
+libsystemd = { version = "0.7.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tokio-vsock = { version = "0.3.1", optional = true }
@@ -32,6 +34,7 @@ protobuf-codegen = "3.1.0"
 default = ["sync"]
 async = ["async-trait", "tokio", "futures", "tokio-vsock"]
 sync = []
+fdstore = ["libsystemd"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/asynchronous/fdstore.rs
+++ b/src/asynchronous/fdstore.rs
@@ -1,0 +1,154 @@
+use crate::{error::Result, proto::GenMessage, Error};
+use std::{collections::HashMap, io::ErrorKind, ops::DerefMut, sync::Arc};
+use tokio::{
+    fs::File,
+    io::{AsyncSeekExt, AsyncWriteExt},
+    sync::Mutex,
+};
+
+const SOCK_NAME_LEN: usize = 36;
+
+#[derive(Clone)]
+pub struct MessageStore {
+    file: Arc<Mutex<File>>,
+    cache: Arc<Mutex<HashMap<String, Vec<SockMessage>>>>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct SockMessage {
+    pub(crate) sock_name: String,
+    pub(crate) id: u64,
+    pub(crate) message: GenMessage,
+}
+
+impl SockMessage {
+    pub async fn write_to(&self, mut writer: impl tokio::io::AsyncWriteExt + Unpin) -> Result<()> {
+        writer
+            .write_all(self.sock_name.as_bytes())
+            .await
+            .map_err(|e| Error::Others(e.to_string()))?;
+        writer
+            .write_u64(self.id)
+            .await
+            .map_err(|e| Error::Others(e.to_string()))?;
+        self.message.write_to(writer).await?;
+        Ok(())
+    }
+
+    pub async fn read_from(mut reader: impl tokio::io::AsyncReadExt + Unpin) -> Result<Self> {
+        let mut sock_name_buf = vec![0u8; SOCK_NAME_LEN];
+        let len = reader.read_exact(&mut sock_name_buf).await.map_err(|e| {
+            if e.kind() == ErrorKind::UnexpectedEof {
+                Error::Eof
+            } else {
+                Error::Others(format!("failed to read messages from memfd {}", e))
+            }
+        })?;
+        if len < SOCK_NAME_LEN {
+            return Err(Error::Others(format!("read {} bytes for socket name", len)));
+        }
+        let sock_name =
+            String::from_utf8(sock_name_buf).map_err(|e| Error::Others(e.to_string()))?;
+        let id = reader
+            .read_u64()
+            .await
+            .map_err(|e| Error::Others(e.to_string()))?;
+        let message = GenMessage::read_from(reader).await?;
+        Ok(Self {
+            sock_name,
+            id,
+            message,
+        })
+    }
+}
+
+impl MessageStore {
+    pub async fn load(mut f: File) -> Result<Self> {
+        f.seek(std::io::SeekFrom::Start(0))
+            .await
+            .map_err(|e| Error::Others(e.to_string()))?;
+        let s = Self {
+            file: Arc::new(Mutex::new(f)),
+            cache: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let file = s.file.clone();
+        let mut f = file.lock().await;
+        loop {
+            let a = SockMessage::read_from(f.deref_mut()).await;
+            match a {
+                Ok(m) => {
+                    trace!("load a message from {}, with id {}", m.sock_name, m.id);
+                    s.insert_sock_message(m).await;
+                }
+                Err(e) => match e {
+                    Error::Eof => {
+                        break;
+                    }
+                    _ => {
+                        return Err(Error::Others(format!(
+                            "failed to read message from memfd in fdstore: {}",
+                            e
+                        )));
+                    }
+                },
+            }
+        }
+        return Ok(s);
+    }
+
+    pub async fn insert(&self, sock_name: String, id: u64, m: GenMessage) {
+        assert_eq!(SOCK_NAME_LEN, sock_name.len());
+        self.insert_sock_message(SockMessage {
+            sock_name,
+            id,
+            message: m,
+        })
+        .await;
+        self.dump().await;
+    }
+
+    pub async fn dump(&self) {
+        let mut file = self.file.lock().await;
+        file.set_len(0).await.unwrap_or_default();
+        file.rewind().await.unwrap_or_default();
+        let cache = self.cache.lock().await;
+        for v in cache.values() {
+            for m in v {
+                m.write_to(file.deref_mut()).await.unwrap_or_default();
+            }
+        }
+        file.flush().await.unwrap_or_default();
+    }
+
+    pub async fn get_messages(&self, key: &str) -> Vec<SockMessage> {
+        if let Some(l) = self.cache.lock().await.get(key) {
+            l.clone()
+        } else {
+            vec![]
+        }
+    }
+
+    pub async fn remove(&self, sock_name: String, id: u64) {
+        self.remove_sock_message(sock_name, id).await;
+        self.dump().await;
+    }
+
+    async fn remove_sock_message(&self, sock_name: String, id: u64) {
+        let mut cache = self.cache.lock().await;
+        if let Some(v) = cache.get_mut(&sock_name) {
+            v.retain(|x| x.id != id);
+        }
+    }
+
+    async fn insert_sock_message(&self, m: SockMessage) {
+        let mut cache = self.cache.lock().await;
+        let sock_name = m.sock_name.clone();
+        if let Some(v) = cache.get_mut(&sock_name) {
+            v.push(m);
+        } else {
+            let mut l = Vec::new();
+            l.push(m);
+            cache.insert(sock_name, l);
+        }
+    }
+}

--- a/src/asynchronous/mod.rs
+++ b/src/asynchronous/mod.rs
@@ -12,6 +12,8 @@ mod stream;
 #[doc(hidden)]
 mod utils;
 mod connection;
+#[cfg(feature = "fdstore")]
+mod fdstore;
 pub mod shutdown;
 mod unix_incoming;
 

--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -78,6 +78,8 @@ pub struct Server {
 
     #[cfg(feature = "fdstore")]
     message_store: Option<MessageStore>,
+    #[cfg(feature = "fdstore")]
+    fdstore_enabled: bool,
 }
 
 impl Default for Server {
@@ -90,6 +92,8 @@ impl Default for Server {
             stop_listen_tx: None,
             #[cfg(feature = "fdstore")]
             message_store: Default::default(),
+            #[cfg(feature = "fdstore")]
+            fdstore_enabled: false,
         }
     }
 }
@@ -131,6 +135,12 @@ impl Server {
         Ok(self)
     }
 
+    #[cfg(feature = "fdstore")]
+    pub fn enable_fdstore(mut self) -> Self {
+        self.fdstore_enabled = true;
+        self
+    }
+
     pub fn register_service(mut self, new: HashMap<String, Service>) -> Server {
         let services = Arc::get_mut(&mut self.services).unwrap();
         services.extend(new);
@@ -153,7 +163,10 @@ impl Server {
         match self.domain.as_ref() {
             Some(Domain::Unix) => {
                 #[cfg(feature = "fdstore")]
-                self.serve_stored_conns().await?;
+                if self.fdstore_enabled {
+                    self.serve_stored_conns().await?;
+                }
+
                 let sys_unix_listener;
                 unsafe {
                     sys_unix_listener = SysUnixListener::from_raw_fd(listenfd);
@@ -379,16 +392,20 @@ async fn spawn_connection_handler<C>(
     };
     let conn = Connection::new(conn, delegate, sock_name.clone());
     let message_store = message_store.clone();
-    if let Err(e) = libsystemd::daemon::notify_with_fds(
-        false,
-        &[
-            libsystemd::daemon::NotifyState::Fdname(sock_name.to_string()),
-            libsystemd::daemon::NotifyState::Fdstore,
-        ],
-        &[fd],
-    ) {
-        warn!("failed to notify fds to systemd: {}", e);
+    // fdstore is not enable if message store is None
+    if message_store.is_some() {
+        if let Err(e) = libsystemd::daemon::notify_with_fds(
+            false,
+            &[
+                libsystemd::daemon::NotifyState::Fdname(sock_name.to_string()),
+                libsystemd::daemon::NotifyState::Fdstore,
+            ],
+            &[fd],
+        ) {
+            warn!("failed to notify fds to systemd: {}", e);
+        }
     }
+
     spawn(async move {
         #[cfg(feature = "fdstore")]
         if let Some(store) = message_store {

--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -46,6 +46,9 @@ use crate::r#async::stream::{
 use crate::r#async::utils;
 use crate::r#async::{MethodHandler, StreamHandler, TtrpcContext};
 
+#[cfg(feature = "fdstore")]
+use crate::r#async::fdstore::MessageStore;
+
 const DEFAULT_CONN_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(5000);
 const DEFAULT_SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(10000);
 
@@ -72,6 +75,9 @@ pub struct Server {
 
     shutdown: shutdown::Notifier,
     stop_listen_tx: Option<Sender<Sender<RawFd>>>,
+
+    #[cfg(feature = "fdstore")]
+    message_store: Option<MessageStore>,
 }
 
 impl Default for Server {
@@ -82,6 +88,8 @@ impl Default for Server {
             domain: None,
             shutdown: shutdown::with_timeout(DEFAULT_SERVER_SHUTDOWN_TIMEOUT).0,
             stop_listen_tx: None,
+            #[cfg(feature = "fdstore")]
+            message_store: Default::default(),
         }
     }
 }
@@ -140,9 +148,12 @@ impl Server {
 
     pub async fn start(&mut self) -> Result<()> {
         let listenfd = self.get_listenfd()?;
+        debug!("start ttrpc server");
 
         match self.domain.as_ref() {
             Some(Domain::Unix) => {
+                #[cfg(feature = "fdstore")]
+                self.serve_stored_conns().await?;
                 let sys_unix_listener;
                 unsafe {
                     sys_unix_listener = SysUnixListener::from_raw_fd(listenfd);
@@ -168,6 +179,86 @@ impl Server {
         }
     }
 
+    // serve_stored_conns serves the stored connections in fd store of systemd.
+    // when "fdstore" feature enabled, all the established connections
+    // will send to systemd by calling `notify_with_fds` of libsystemd, with `NotifyState::Fdstore`
+    // and systemd will keep it unless we remove it, also by calling `notify_with_fds` with `NotifyState::FdstoreRemove`
+    // The service can receive the fd from fdstore by calling `receive_descriptors_with_names`, everytime it restart.
+    // we also create a memfd of name "message_store" and send it to fdstore, every received ttrpc request will be stored in it.
+    // so everytime we restart, we can get the stored connections and unfinished request in the connections,
+    // we can continue serve the connections so that the ttrpc session will not be interrputed by the service restart.
+    // but there is a restriction of this: the ttrpc service should be reentrant.
+    #[cfg(feature = "fdstore")]
+    async fn serve_stored_conns(&mut self) -> Result<()> {
+        use std::ffi::CStr;
+        use std::os::fd::IntoRawFd;
+
+        use libsystemd::daemon::NotifyState;
+        use nix::sys::memfd::{memfd_create, MemFdCreateFlag};
+        use tokio::{fs::File, net::UnixStream};
+
+        use crate::asynchronous::fdstore::MessageStore;
+        debug!("serve stored connection from systemd");
+
+        let fds = libsystemd::activation::receive_descriptors_with_names(false).unwrap_or_default();
+        let mut mem_fd = None;
+        let mut conns = HashMap::new();
+        for (fd, name) in fds {
+            let fd = fd.into_raw_fd();
+            debug!("received an fd {} from fd store: {}", name, fd);
+            if name == "message_store" {
+                mem_fd = Some(fd);
+                continue;
+            }
+            let conn = unsafe {
+                UnixStream::from_std(std::os::unix::net::UnixStream::from_raw_fd(fd))
+                    .map_err(|e| Error::Socket(e.to_string()))?
+            };
+            conns.insert(name.clone(), conn);
+            libsystemd::daemon::notify_with_fds(
+                false,
+                &[NotifyState::Fdname(name), NotifyState::FdstoreRemove],
+                &[],
+            )
+            .unwrap();
+        }
+        let mem_fd = if let Some(fd) = mem_fd {
+            fd
+        } else {
+            let fd = memfd_create(
+                CStr::from_bytes_with_nul(b"message_store\0").unwrap(),
+                MemFdCreateFlag::MFD_CLOEXEC,
+            )?;
+            libsystemd::daemon::notify_with_fds(
+                false,
+                &[
+                    NotifyState::Fdname("message_store".to_string()),
+                    NotifyState::Fdstore,
+                ],
+                &[fd],
+            )
+            .unwrap();
+            fd
+        };
+        let mem_file = unsafe { File::from_raw_fd(mem_fd) };
+        let store = MessageStore::load(mem_file).await?;
+        self.message_store = Some(store);
+        let shutdown_waiter = self.shutdown.subscribe();
+        for (name, v) in conns {
+            let fd = v.as_raw_fd();
+            spawn_connection_handler(
+                fd,
+                v,
+                self.services.clone(),
+                shutdown_waiter.clone(),
+                self.message_store.clone(),
+                name,
+            )
+            .await;
+        }
+        Ok(())
+    }
+
     async fn do_start<I, S>(&mut self, mut incoming: I) -> Result<()>
     where
         I: Stream<Item = std::io::Result<S>> + Unpin + Send + 'static + AsRawFd,
@@ -179,7 +270,8 @@ impl Server {
 
         let (stop_listen_tx, mut stop_listen_rx) = channel(1);
         self.stop_listen_tx = Some(stop_listen_tx);
-
+        #[cfg(feature = "fdstore")]
+        let message_store = self.message_store.clone();
         spawn(async move {
             loop {
                 select! {
@@ -189,13 +281,23 @@ impl Server {
                             match conn {
                                 Ok(conn) => {
                                     let fd = conn.as_raw_fd();
-                                    // spawn a connection handler, would not block
-                                    spawn_connection_handler(
-                                        fd,
-                                        conn,
-                                        services.clone(),
-                                        shutdown_waiter.clone(),
-                                    ).await;
+                                        // spawn a connection handler, would not block
+                                        #[cfg(feature = "fdstore")]
+                                        spawn_connection_handler(
+                                            fd,
+                                            conn,
+                                            services.clone(),
+                                            shutdown_waiter.clone(),
+                                            message_store.clone(),
+                                            uuid::Uuid::new_v4().to_string(),
+                                        ).await;
+                                        #[cfg(not(feature = "fdstore"))]
+                                        spawn_connection_handler(
+                                            fd,
+                                            conn,
+                                            services.clone(),
+                                            shutdown_waiter.clone(),
+                                        ).await;
                                 }
                                 Err(e) => {
                                     error!("{:?}", e)
@@ -256,6 +358,58 @@ impl Server {
     }
 }
 
+#[cfg(feature = "fdstore")]
+async fn spawn_connection_handler<C>(
+    fd: RawFd,
+    conn: C,
+    services: Arc<HashMap<String, Service>>,
+    shutdown_waiter: shutdown::Waiter,
+    #[cfg(feature = "fdstore")] message_store: Option<MessageStore>,
+    #[cfg(feature = "fdstore")] sock_name: String,
+) where
+    C: AsyncRead + AsyncWrite + AsRawFd + Send + 'static,
+{
+    let delegate = ServerBuilder {
+        fd,
+        services,
+        streams: Arc::new(Mutex::new(HashMap::new())),
+        shutdown_waiter,
+        message_store: message_store.clone(),
+        sock_name: sock_name.clone(),
+    };
+    let conn = Connection::new(conn, delegate, sock_name.clone());
+    let message_store = message_store.clone();
+    if let Err(e) = libsystemd::daemon::notify_with_fds(
+        false,
+        &[
+            libsystemd::daemon::NotifyState::Fdname(sock_name.to_string()),
+            libsystemd::daemon::NotifyState::Fdstore,
+        ],
+        &[fd],
+    ) {
+        warn!("failed to notify fds to systemd: {}", e);
+    }
+    spawn(async move {
+        #[cfg(feature = "fdstore")]
+        if let Some(store) = message_store {
+            conn.run_with_message_store(store)
+                .await
+                .map_err(|e| {
+                    trace!("connection run error. {}", e);
+                })
+                .ok();
+        } else {
+            conn.run()
+                .await
+                .map_err(|e| {
+                    trace!("connection run error. {}", e);
+                })
+                .ok();
+        }
+    });
+}
+
+#[cfg(not(feature = "fdstore"))]
 async fn spawn_connection_handler<C>(
     fd: RawFd,
     conn: C,
@@ -271,6 +425,7 @@ async fn spawn_connection_handler<C>(
         shutdown_waiter,
     };
     let conn = Connection::new(conn, delegate);
+
     spawn(async move {
         conn.run()
             .await
@@ -298,6 +453,10 @@ struct ServerBuilder {
     services: Arc<HashMap<String, Service>>,
     streams: Arc<Mutex<HashMap<u32, ResultSender>>>,
     shutdown_waiter: shutdown::Waiter,
+    #[cfg(feature = "fdstore")]
+    message_store: Option<MessageStore>,
+    #[cfg(feature = "fdstore")]
+    sock_name: String,
 }
 
 impl Builder for ServerBuilder {
@@ -317,6 +476,10 @@ impl Builder for ServerBuilder {
                 streams: self.streams.clone(),
                 server_shutdown: self.shutdown_waiter.clone(),
                 handler_shutdown: disconnect_notifier,
+                #[cfg(feature = "fdstore")]
+                message_store: self.message_store.clone(),
+                #[cfg(feature = "fdstore")]
+                sock_name: self.sock_name.clone(),
             },
             ServerWriter { rx },
         )
@@ -343,6 +506,10 @@ struct ServerReader {
     streams: Arc<Mutex<HashMap<u32, ResultSender>>>,
     server_shutdown: shutdown::Waiter,
     handler_shutdown: shutdown::Notifier,
+    #[cfg(feature = "fdstore")]
+    sock_name: String,
+    #[cfg(feature = "fdstore")]
+    message_store: Option<MessageStore>,
 }
 
 #[async_trait]
@@ -368,13 +535,34 @@ impl ReaderDelegate for ServerReader {
             .ok();
     }
 
-    async fn handle_msg(&self, msg: GenMessage) {
+    #[cfg(not(feature = "fdstore"))]
+    async fn handle_msg(&self, _id: u64, msg: GenMessage) {
         let handler_shutdown_waiter = self.handler_shutdown.subscribe();
         let context = self.context();
         let (wait_tx, wait_rx) = tokio::sync::oneshot::channel::<()>();
         spawn(async move {
             select! {
                 _ = context.handle_msg(msg, wait_tx) => {}
+                _ = handler_shutdown_waiter.wait_shutdown() => {}
+            }
+        });
+        wait_rx.await.unwrap_or_default();
+    }
+
+    #[cfg(feature = "fdstore")]
+    async fn handle_msg(&self, id: u64, msg: GenMessage) {
+        let handler_shutdown_waiter = self.handler_shutdown.subscribe();
+        let context = self.context();
+        let message_store = self.message_store.clone();
+        let sock_name = self.sock_name.clone();
+        let (wait_tx, wait_rx) = tokio::sync::oneshot::channel::<()>();
+        spawn(async move {
+            select! {
+                _ = context.handle_msg(msg, wait_tx) => {
+                    if let Some(store) = message_store {
+                        store.remove(sock_name, id).await;
+                    }
+                }
                 _ = handler_shutdown_waiter.wait_shutdown() => {}
             }
         });

--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -16,4 +16,4 @@ readme = "README.md"
 protobuf-support = "3.1.0"
 protobuf = { version = "2.27.1" }
 protobuf-codegen = "3.1.0"
-ttrpc-compiler = { path = "../ttrpc-compiler" }
+ttrpc-compiler = { path = "../compiler" }


### PR DESCRIPTION
use fdstore of systemd to store the connections and request in systemd so that we can serve the connection and request after restart.

![image](https://github.com/user-attachments/assets/d735612f-509e-4101-80e1-37198fbb4aa5)

the sequence diagram:
![fdstore1](https://github.com/user-attachments/assets/1d2b33af-4745-4a59-a49d-af30af7e59ed)


TODO:
1. add a flag in Server to choose if we use fdstore even the feature gate is open
2. introduce a kv store for the message store, currently we just write all messages everytime we insert or delete the messasge.



